### PR TITLE
ledger: return error if policy is not loaded while signing

### DIFF
--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -103,8 +103,11 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
                 let input = psbt.inputs.get_mut(i).ok_or(HWIError::DeviceDidNotSign)?;
                 input.partial_sigs.insert(key, sig);
             }
+            Ok(())
+        } else {
+            // Ledger cannot sign without policy.
+            Err(HWIError::UnimplementedMethod)
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Ledger wallet cannot sign without policy.

close #11