### PR TITLE
Add enumerate to Specter serial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ futures = "0.3"
 bitcoin = { version = "0.29.1", features = ["base64", "serde"] }
 
 # specter & ledger
-tokio = { version = "1.21.0", features = ["net", "io-util", "sync"], optional = true }
+tokio = { version = "1.21.0", features = ["net", "time", "io-util", "sync"], optional = true }
 
 # specter
 tokio-serial = { version = "5.4.1", optional = true }
-serialport = { version = "4", optional = true }
+serialport = { version = "4.2", optional = true }
 
 # ledger
 regex = { version = "1.6.0", optional = true }

--- a/examples/hwi.rs
+++ b/examples/hwi.rs
@@ -37,8 +37,10 @@ pub async fn list_hardware_wallets() -> Vec<Box<dyn HWI + Send>> {
     }
 
     #[cfg(feature = "specter")]
-    if let Ok(device) = Specter::try_connect_serial().await {
-        hws.push(device.into());
+    if let Ok(devices) = Specter::enumerate().await {
+        for device in devices {
+            hws.push(device.into());
+        }
     }
 
     #[cfg(feature = "ledger")]


### PR DESCRIPTION
Specter is not always recognized by serial port as UsbInfo but Pci, this PR handle the case and check for multiple specter connected