### PR TITLE
Use ledger-transport-hidapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bitcoin"]
 default = ["ledger", "specter", "bitbox"]
 bitbox = ["tokio", "hidapi", "bitbox-api", "regex" ]
 specter = ["tokio", "tokio-serial", "serialport"]
-ledger = ["regex", "tokio", "ledger_bitcoin_client", "ledger-transport-hid", "ledger-apdu", "hidapi"]
+ledger = ["regex", "tokio", "ledger_bitcoin_client", "ledger-transport-hidapi", "ledger-apdu", "hidapi"]
 
 [dependencies]
 base64 = "0.13.0"
@@ -30,7 +30,7 @@ bitbox-api = { version = "0.1.1", default-features = false, features = ["usb", "
 # ledger
 ledger_bitcoin_client = { version = "0.3.2", optional = true }
 ledger-apdu = { version = "0.10", optional = true }
-ledger-transport-hid = { git = "https://github.com/edouardparis/ledger-rs", branch = "hidapi-2.4.1", optional = true }
+ledger-transport-hidapi = { version = "0.10.0", optional = true }
 
 #bitbox & ledger
 hidapi = { version = "2.4.1", features = ["linux-static-hidraw"], default-features = false, optional = true }

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -13,7 +13,7 @@ use ledger_bitcoin_client::psbt::PartialSignature;
 use regex::Regex;
 
 use ledger_apdu::APDUAnswer;
-use ledger_transport_hid::TransportNativeHID;
+use ledger_transport_hidapi::TransportNativeHID;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,


### PR DESCRIPTION
We use a fork of ledger-transport-hid in order
to have a common version of hidapi with other dependencies like the bitbox-api and be able to publish async-hwi on crates.io