### PR TITLE
Add  Error::UserRefused variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,20 @@ regex = ["dep:regex"]
 [dependencies]
 async-trait = "0.1.52"
 futures = "0.3"
-bitcoin = { version = "0.30.0", default-features = false, features = ["base64", "serde", "std"] }
+bitcoin = { version = "0.31", default-features = false, features = ["base64", "serde", "std"] }
 
 # specter
 tokio-serial = { version = "5.4.1", optional = true }
 serialport = { version = "4.2", optional = true }
 
 #bitbox
-bitbox-api = { version = "0.2.2", default-features = false, features = ["usb", "tokio", "multithreaded"], optional = true }
+bitbox-api = { git = "https://github.com/edouardparis/bitbox-api-rs.git", branch = "bitcoin-0.31", default-features = false, features = ["usb", "tokio", "multithreaded"], optional = true }
 
 #coldcard
-coldcard = { git = "https://github.com/darosior/rust-coldcard.git", branch = "2401_api_feature_msrv", default-features = false, features = ["linux-static-hidraw"], optional = true }
+coldcard = { git = "https://github.com/alfred-hodler/rust-coldcard.git", branch = "redo_api", optional = true }
 
 # ledger
-ledger_bitcoin_client = { version = "0.3.2", optional = true }
+ledger_bitcoin_client = { git = "https://github.com/LedgerHQ/app-bitcoin-new.git", branch = "develop", optional = true }
 ledger-apdu = { version = "0.10", optional = true }
 ledger-transport-hidapi = { version = "0.10.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ pub trait HWI: Debug {
     /// Get master fingerprint.
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// Get the xpub with the given derivation path.
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, Error>;
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
     /// Register a new wallet policy
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
+    /// Returns true if the wallet is registered
+    async fn is_wallet_registered(&self, name: &str, policy: &str) -> Result<bool, HWIError>; 
     /// Display an address on the device screen
     async fn display_address(&self, script: &AddressScript) -> Result<(), Error>;
     /// Sign a partially signed bitcoin transaction (PSBT).

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/hwi.rs"
 
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
-bitcoin = "0.30.0"
+bitcoin = "0.31"
 hex = "0.4"
 async-hwi = { workspace = true }
 tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "io-util", "sync"] }

--- a/cli/src/bin/hwi.rs
+++ b/cli/src/bin/hwi.rs
@@ -148,12 +148,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Commands::Device(DeviceCommands::List) => {
             for device in command::list(args.network, None).await? {
-                eprintln!(
-                    "{} {} {}",
-                    device.device_kind(),
-                    device.get_master_fingerprint().await?,
-                    device.get_version().await.map(|v| v.to_string())?
-                );
+                eprint!("{}", device.get_master_fingerprint().await?,);
+                eprint!(" {}", device.device_kind());
+                if let Ok(version) = device.get_version().await.map(|v| v.to_string()) {
+                    eprint!(" {}", version);
+                }
+                eprintln!();
             }
         }
         Commands::Xpub(XpubCommands::Get { path }) => {

--- a/src/bitbox.rs
+++ b/src/bitbox.rs
@@ -9,7 +9,7 @@ use bitbox_api::{
     Keypath, PairedBitBox, PairingBitBox,
 };
 use bitcoin::{
-    bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint},
+    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
     psbt::Psbt,
 };
 use regex::Regex;
@@ -183,7 +183,7 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
         Ok(Fingerprint::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
         let fg = self
             .client
             .btc_xpub(
@@ -202,7 +202,7 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
             )
             .await
             .map_err(|e| HWIError::Device(e.to_string()))?;
-        Ok(ExtendedPubKey::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
+        Ok(Xpub::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
     }
 
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {
@@ -399,7 +399,7 @@ pub fn extract_script_config_policy(policy: &str) -> Result<Policy, HWIError> {
     let mut pubkeys: Vec<KeyInfo> = Vec::new();
     for (i, key_str) in pubkeys_str.iter().enumerate() {
         descriptor_template = descriptor_template.replace(key_str, &format!("@{}", i));
-        let pubkey = if let Ok(key) = ExtendedPubKey::from_str(key_str) {
+        let pubkey = if let Ok(key) = Xpub::from_str(key_str) {
             KeyInfo {
                 path: None,
                 master_fingerprint: None,
@@ -424,7 +424,7 @@ pub fn extract_script_config_policy(policy: &str) -> Result<Policy, HWIError> {
             };
 
             KeyInfo {
-                xpub: ExtendedPubKey::from_str(xpub_str)
+                xpub: Xpub::from_str(xpub_str)
                     .map_err(|e| HWIError::InvalidParameter("policy", e.to_string()))?,
                 path: Some(derivation_path),
                 master_fingerprint: Some(fingerprint),
@@ -480,7 +480,7 @@ impl From<Policy> for BtcScriptConfig {
 
 #[derive(Clone)]
 pub struct KeyInfo {
-    xpub: ExtendedPubKey,
+    xpub: Xpub,
     path: Option<DerivationPath>,
     master_fingerprint: Option<Fingerprint>,
 }

--- a/src/bitbox.rs
+++ b/src/bitbox.rs
@@ -3,7 +3,7 @@ use api::btc::make_script_config_simple;
 use async_trait::async_trait;
 use bitbox_api::{
     btc::KeyOriginInfo,
-    error::Error,
+    error::{BitBoxError, Error},
     pb::{self, BtcScriptConfig},
     usb::UsbError,
     Keypath, PairedBitBox, PairingBitBox,
@@ -361,8 +361,12 @@ impl From<UsbError> for HWIError {
 }
 
 impl From<Error> for HWIError {
-    fn from(value: Error) -> Self {
-        HWIError::Device(value.to_string())
+    fn from(e: Error) -> Self {
+        if let Error::BitBox(BitBoxError::UserAbort) = e {
+            HWIError::UserRefused
+        } else {
+            HWIError::Device(e.to_string())
+        }
     }
 }
 

--- a/src/coldcard.rs
+++ b/src/coldcard.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use bitcoin::{
-    bip32::{DerivationPath, ExtendedPubKey, Fingerprint},
+    bip32::{DerivationPath, Fingerprint, Xpub},
     psbt::Psbt,
 };
 
@@ -65,18 +65,18 @@ impl HWI for Coldcard {
             .device()?
             .xpub(None)
             .map_err(|e| HWIError::Device(e.to_string()))?;
-        let xpub = ExtendedPubKey::from_str(&s).map_err(|e| HWIError::Device(e.to_string()))?;
+        let xpub = Xpub::from_str(&s).map_err(|e| HWIError::Device(e.to_string()))?;
         Ok(xpub.fingerprint())
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
         let path = coldcard::protocol::DerivationPath::new(&path.to_string())
             .map_err(|e| HWIError::InvalidParameter("path", format!("{:?}", e)))?;
         let s = self
             .device()?
             .xpub(Some(path))
             .map_err(|e| HWIError::Device(e.to_string()))?;
-        ExtendedPubKey::from_str(&s).map_err(|e| HWIError::Device(e.to_string()))
+        Xpub::from_str(&s).map_err(|e| HWIError::Device(e.to_string()))
     }
 
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -330,6 +330,11 @@ impl Transport for TransportTcp {
 
 impl<T: core::fmt::Debug> From<BitcoinClientError<T>> for HWIError {
     fn from(e: BitcoinClientError<T>) -> HWIError {
+        if let BitcoinClientError::Device { status, .. } = e {
+            if status == StatusWord::Deny {
+                return HWIError::UserRefused;
+            }
+        };
         HWIError::Device(format!("{:#?}", e))
     }
 }

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use bitcoin::{
-    bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint},
+    bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub},
     psbt::Psbt,
 };
 use ledger_bitcoin_client::psbt::PartialSignature;
@@ -92,7 +92,7 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
         Ok(self.client.get_master_fingerprint().await?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
         Ok(self
             .client
             .get_extended_pubkey(path, self.options.display_xpub)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pub mod utils;
 
 use async_trait::async_trait;
 use bitcoin::{
-    bip32::{DerivationPath, ExtendedPubKey, Fingerprint},
-    psbt::PartiallySignedTransaction as Psbt,
+    bip32::{DerivationPath, Fingerprint, Xpub},
+    psbt::Psbt,
 };
 
 use std::{fmt::Debug, str::FromStr};
@@ -68,7 +68,7 @@ pub trait HWI: Debug {
     /// Get master fingerprint.
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// Get the xpub with the given derivation path.
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, Error>;
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
     /// Register a new wallet policy.
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// Returns true if the wallet is registered on the device.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub enum Error {
     DeviceDidNotSign,
     Device(String),
     Unexpected(&'static str),
+    UserRefused,
 }
 
 impl std::fmt::Display for Error {
@@ -46,6 +47,7 @@ impl std::fmt::Display for Error {
             Error::Device(e) => write!(f, "{}", e),
             Error::InvalidParameter(param, e) => write!(f, "Invalid parameter {}: {}", param, e),
             Error::Unexpected(e) => write!(f, "{}", e),
+            Error::UserRefused => write!(f, "User refused operation"),
         }
     }
 }

--- a/src/specter.rs
+++ b/src/specter.rs
@@ -2,8 +2,8 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 use bitcoin::{
-    bip32::{DerivationPath, ExtendedPubKey, Fingerprint},
-    psbt::PartiallySignedTransaction as Psbt,
+    bip32::{DerivationPath, Fingerprint, Xpub},
+    psbt::Psbt,
 };
 
 use serialport::{available_ports, SerialPortType};
@@ -32,16 +32,11 @@ impl<T: Transport> Specter<T> {
             })
     }
 
-    pub async fn get_extended_pubkey(
-        &self,
-        path: &DerivationPath,
-    ) -> Result<ExtendedPubKey, SpecterError> {
+    pub async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, SpecterError> {
         self.transport
             .request(&format!("\r\n\r\nxpub {}\r\n", path))
             .await
-            .and_then(|resp| {
-                ExtendedPubKey::from_str(&resp).map_err(|e| SpecterError::Device(e.to_string()))
-            })
+            .and_then(|resp| Xpub::from_str(&resp).map_err(|e| SpecterError::Device(e.to_string())))
     }
 
     /// If the descriptor contains master public keys but doesn't contain wildcard derivations,
@@ -87,7 +82,7 @@ impl<T: Transport + Sync + Send> HWI for Specter<T> {
         Ok(self.fingerprint().await?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<ExtendedPubKey, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
         Ok(self.get_extended_pubkey(path).await?)
     }
 


### PR DESCRIPTION
This error variant is required for clients to understand if the error is a communication error or simply the user refusing the operation on the device.

based on #64 