### PR TITLE
Update Coldcard lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serialport = { version = "4.2", optional = true }
 bitbox-api = { version = "0.2.3", default-features = false, features = ["usb", "tokio", "multithreaded"], optional = true }
 
 #coldcard
-coldcard = { version = "0.11.0", optional = true }
+coldcard = { version = "0.12.1", optional = true }
 
 # ledger
 ledger_bitcoin_client = { version = "0.4.0", optional = true }


### PR DESCRIPTION
The latest version of the `coldcard` crate mitigates a firmware bug that causes the host side of the wire to hang when the `fram` response is sent. It's not a very common scenario but it'll cause anything communicating with a coldcard to hang.

I've reported the bug to Coinkite but the fix won't help anyone with an older firmware, so the mitigation on the Rust side fixes the problem for everyone.