### PR TITLE
[CLI] Force display mode if we fail to get an xpub w/ ledger

### DIFF
--- a/cli/src/bin/hwi.rs
+++ b/cli/src/bin/hwi.rs
@@ -163,7 +163,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         continue;
                     }
                 }
-                eprintln!("{}", device.get_extended_pubkey(&path).await?);
+                let response = device.get_extended_pubkey(&path, false).await;
+                match response {
+                    Ok(r) => eprintln!("{}", r),
+                    Err(e) => {
+                        if device.device_kind() == DeviceKind::Ledger {
+                            eprintln!("{}", device.get_extended_pubkey(&path, true).await?);
+                        } else {
+                            eprintln!("{}", e);
+                        }
+                    }
+                }
             }
         }
         Commands::Wallet(WalletCommands::Register { name, policy }) => {

--- a/src/bitbox.rs
+++ b/src/bitbox.rs
@@ -188,7 +188,7 @@ impl<T: Runtime + Sync + Send> HWI for BitBox02<T> {
         Ok(Fingerprint::from_str(&fg).map_err(|e| HWIError::Device(e.to_string()))?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath, _: bool) -> Result<Xpub, HWIError> {
         let fg = self
             .client
             .btc_xpub(

--- a/src/coldcard.rs
+++ b/src/coldcard.rs
@@ -63,7 +63,7 @@ impl HWI for Coldcard {
         Ok(xpub.fingerprint())
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath, _: bool) -> Result<Xpub, HWIError> {
         let path = coldcard::protocol::DerivationPath::new(&path.to_string())
             .map_err(|e| HWIError::InvalidParameter("path", format!("{:?}", e)))?;
         let s = self.device()?.xpub(Some(path))?;

--- a/src/jade/mod.rs
+++ b/src/jade/mod.rs
@@ -156,11 +156,11 @@ impl<T: Transport + Sync + Send> HWI for Jade<T> {
     }
 
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, HWIError> {
-        let xpub = self.get_extended_pubkey(&DerivationPath::master()).await?;
+        let xpub = self.get_extended_pubkey(&DerivationPath::master(), false).await?;
         Ok(xpub.fingerprint())
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath, _: bool) -> Result<Xpub, HWIError> {
         let s: String = self
             .transport
             .request(

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -90,11 +90,12 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
         Ok(self.client.get_master_fingerprint().await?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
-        Ok(self
-            .client
-            .get_extended_pubkey(path, self.options.display_xpub)
-            .await?)
+    async fn get_extended_pubkey(
+        &self,
+        path: &DerivationPath,
+        display_mode: bool,
+    ) -> Result<Xpub, HWIError> {
+        Ok(self.client.get_extended_pubkey(path, display_mode).await?)
     }
 
     async fn display_address(&self, script: &AddressScript) -> Result<(), HWIError> {
@@ -104,7 +105,7 @@ impl<T: Transport + Sync + Send> HWI for Ledger<T> {
                 let (hardened_children, normal_children) = children.split_at(3);
                 let path = DerivationPath::from(hardened_children);
                 let fg = self.get_master_fingerprint().await?;
-                let xpub = self.get_extended_pubkey(&path).await?;
+                let xpub = self.get_extended_pubkey(&path, false).await?;
                 let policy = format!(
                     "tr([{}{}]{}/**)",
                     fg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub trait HWI: Debug {
     /// Get master fingerprint.
     async fn get_master_fingerprint(&self) -> Result<Fingerprint, Error>;
     /// Get the xpub with the given derivation path.
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, Error>;
+    async fn get_extended_pubkey(&self, path: &DerivationPath, display_mode: bool) -> Result<Xpub, Error>;
     /// Register a new wallet policy.
     async fn register_wallet(&self, name: &str, policy: &str) -> Result<Option<[u8; 32]>, Error>;
     /// Returns true if the wallet is registered on the device.

--- a/src/specter.rs
+++ b/src/specter.rs
@@ -96,7 +96,7 @@ impl<T: Transport + Sync + Send> HWI for Specter<T> {
         Ok(self.fingerprint().await?)
     }
 
-    async fn get_extended_pubkey(&self, path: &DerivationPath) -> Result<Xpub, HWIError> {
+    async fn get_extended_pubkey(&self, path: &DerivationPath, _: bool) -> Result<Xpub, HWIError> {
         Ok(self.get_extended_pubkey(path).await?)
     }
 


### PR DESCRIPTION
I hit an issue while trying to get an xpub w/ a not 'standard' derivation path w/ the CLI:

```shell
~/rust/escrow nostr *5 ❯ hwi xpub get --path "m/1465269028'/547967380'/703278800'/311392014'"
Error: Device("Device {\n    command: 0,\n    status: NotSupported,\n}")
```
Ledger devices have a 'security' features, if we want to get an xpub for a  not 'standard' derivation path, we should use the `display` mode where the user add to ACK.  

Approach taken here is : if we fail to get an xpub w/ a ledger, we retry one more time w/ `display` mode activated. 