### PR TITLE
CLI: use async-hwi from workspace

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,5 +16,5 @@ path = "src/bin/hwi.rs"
 clap = { version = "4.4.7", features = ["derive"] }
 bitcoin = "0.31"
 hex = "0.4"
-async-hwi = { version = "0.0.17" }
+async-hwi = { path = "../", version = "0.0.19" }
 tokio = { version = "1", features = ["macros", "net", "rt", "rt-multi-thread", "io-util", "sync"] }


### PR DESCRIPTION
we actually use async-hwi from crates.io as dependency for the cli, this pr switch to the local workspace instead