### PR TITLE
Do not check for Pci in serial com

### DIFF
--- a/src/jade/mod.rs
+++ b/src/jade/mod.rs
@@ -440,7 +440,6 @@ impl SerialTransport {
             Ok(ports) => Ok(ports
                 .into_iter()
                 .filter_map(|p| match p.port_type {
-                    SerialPortType::PciPort => Some(p.port_name),
                     SerialPortType::UsbPort(info) => {
                         if JADE_DEVICE_IDS.contains(&(info.vid, info.pid)) {
                             Some(p.port_name)

--- a/src/specter.rs
+++ b/src/specter.rs
@@ -284,7 +284,6 @@ impl SerialTransport {
             Ok(ports) => Ok(ports
                 .into_iter()
                 .filter_map(|p| match p.port_type {
-                    SerialPortType::PciPort => Some(p.port_name),
                     SerialPortType::UsbPort(info) => {
                         if info.vid == SerialTransport::SPECTER_VID
                             && info.pid == SerialTransport::SPECTER_PID


### PR DESCRIPTION
I do not know what i was thinking while
scanning for Pci port. A Pci port may hold
the communication and it is unclear to know
if it is an external hardware wallet.