### PR TITLE
coldcard: get the tap_key_sig from the signed tx

### DIFF
--- a/src/coldcard.rs
+++ b/src/coldcard.rs
@@ -130,7 +130,10 @@ impl HWI for Coldcard {
                 .append(&mut new_psbt.inputs[i].partial_sigs);
             psbt.inputs[i]
                 .tap_script_sigs
-                .append(&mut new_psbt.inputs[i].tap_script_sigs)
+                .append(&mut new_psbt.inputs[i].tap_script_sigs);
+            if let Some(sig) = new_psbt.inputs[i].tap_key_sig {
+                psbt.inputs[i].tap_key_sig = Some(sig);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This PR fixes an issue where the tap_key_sig was not copied from the tx returned by the device.