### PR TITLE
Fix Specter DIY not detected in Windows

### DIFF
--- a/src/specter.rs
+++ b/src/specter.rs
@@ -8,7 +8,7 @@ use bitcoin::{
     taproot,
 };
 
-use serialport::{available_ports, SerialPortType};
+use serialport::{available_ports, SerialPort, SerialPortType};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt},
     net::TcpStream,
@@ -271,8 +271,11 @@ impl SerialTransport {
     pub const SPECTER_PID: u16 = 38914;
 
     pub fn new(port_name: String) -> Result<Self, SpecterError> {
-        let stream = tokio_serial::new(port_name, 9600)
+        let mut stream = tokio_serial::new(port_name, 9600)
             .open_native_async()
+            .map_err(|e| SpecterError::Device(e.to_string()))?;
+        stream
+            .write_data_terminal_ready(true)
             .map_err(|e| SpecterError::Device(e.to_string()))?;
         Ok(Self {
             stream: Arc::new(Mutex::new(stream)),


### PR DESCRIPTION
Need to explicitly set DTR in Windows before the device will send any replies, as this is not done automatically in the Windows driver (Or most Rust serial interfaces) and is required for this USB/Serial interface. (And probably all devices using the pyboard virtual serial interface)

Tested in Windows 11 and Ubuntu.

